### PR TITLE
Update fleet.yaml to ignore resource Modified by CAPI itself

### DIFF
--- a/clusters/fleet.yaml
+++ b/clusters/fleet.yaml
@@ -1,1 +1,10 @@
 namespace: default
+
+diff:
+  comparePatches:
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerCluster
+    name: cluster1
+    namespace: default
+    operations:
+    - {"op":"remove", "path":"/spec/failureDomains"}


### PR DESCRIPTION
This PR makes this Fleet example Git repo (and Bundle) `Ready` instead of `Modified` under Rancher 2.8.0 once the CAPD cluster is provisioned.

Ref.: https://fleet.rancher.io/bundle-diffs

Before:
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/008e7100-b228-40d8-914c-289104d59323)
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/b08d68a9-da8a-4cd2-a617-6fd34ff2aca7)


After:
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/77855c3f-3b98-4563-b2ad-4f1a1654f9cf)


