### PR TITLE
Deploy in `fleet-default` namespace as any other downstream cluster under Rancher

### DIFF
--- a/classes/fleet.yaml
+++ b/classes/fleet.yaml
@@ -1,3 +1,3 @@
-namespace: default
+namespace: fleet-default
 labels:
   classes: "true"

--- a/clusters/fleet.yaml
+++ b/clusters/fleet.yaml
@@ -1,4 +1,4 @@
-namespace: default
+namespace: fleet-default
 dependsOn:
   - selector:
       matchLabels:


### PR DESCRIPTION
This is useful for CAPD cluster(s) deployed by using `clusterclass` branch in `rancher:v2.8.1` to be available under standard `fleet-default` namespace as any other rancher downstream cluster. 

Without this the provisioned cluster(s) are not available to fleet CD under Rancher.
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/3295aa75-a659-44ea-9959-403838e3eec7)

