### PR TITLE
Ignore modified resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 This repository can be used to import clusters into Rancher using Fleet. There are a number of different branches that you can use that demonstrate different aspects of this integration:
 
-- **main (this branch)** - used for for importing cluster definitions where all clusters within a namespace are automatically imported into Rancher.
+- **[main](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/main)** - used for for importing cluster definitions where all clusters within a namespace are automatically imported into Rancher.
 - **[per-cluster-import](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/per-cluster-import)** - used for importing cluster definitions where individual clusters are marked for auto-importing into Rancher.
 - **[templates](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/templates)** - contains Cluster API templates that are used by the Rancher Turtles documentation.
 - **[cluster-class](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/clusterclass)** - contains a sample using ClusterClass
 - **[aws](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/tree/aws)** - contains a sample using AWS.
+- **docker-rke2 (this branch)** - contains a sample using RKE2 docker provisioner.
+
 
 Switch to the branch to read further information.
 
@@ -14,6 +16,6 @@ Switch to the branch to read further information.
 
 The [clusters](./clusters/) folder contains the definition for the clusters that you want to create and have imported into Rancher Manager. These definitions can be created using **clusterctl** or hand crafted. See the [Rancher Turtles documentation](https://rancher.github.io/turtles-docs/) for further details.
 
-The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **default**.
+The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **fleet-default** (instead of **default** defined in the cluster definitions). The file also contains `diff.comparePatches` block used by fleet to ignore resources modified by Cluster API.
 
-You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **default** namespace to have the cluster auto-imported.
+You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **fleet-default** namespace to have the cluster auto-imported.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Switch to the branch to read further information.
 
 The [clusters](./clusters/) folder contains the definition for the clusters that you want to create and have imported into Rancher Manager. These definitions can be created using **clusterctl** or hand crafted. See the [Rancher Turtles documentation](https://rancher.github.io/turtles-docs/) for further details.
 
-The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **fleet-default** (instead of **default** defined in the cluster definitions). The file also contains `diff.comparePatches` block used by fleet to ignore resources modified by Cluster API.
+The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **default**. The file also contains `diff.comparePatches` block used by fleet to ignore resources modified by Cluster API.
 
-You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **fleet-default** namespace to have the cluster auto-imported.
+You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **default** namespace to have the cluster auto-imported.

--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.26.0
+      customImage: kindest/node:v1.28.0
       bootstrapTimeout: 15m
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -67,7 +67,7 @@ spec:
     kind: DockerMachineTemplate
     name:  cluster1-control-plane
   nodeDrainTimeout: 30s
-  version: v1.26.4+rke2r1
+  version: v1.28.9+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
@@ -77,7 +77,7 @@ metadata:
 spec:
   template:
     spec:
-      customImage: kindest/node:v1.26.0
+      customImage: kindest/node:v1.28.0
       bootstrapTimeout: 15m
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -110,7 +110,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
         name: cluster1-md-0
-      version: v1.26.4+rke2r1
+      version: v1.28.9+rke2r1
 ---
 apiVersion: v1
 data:

--- a/clusters/fleet.yaml
+++ b/clusters/fleet.yaml
@@ -1,10 +1,22 @@
-namespace: default
+namespace: fleet-default
 
 diff:
   comparePatches:
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
     name: cluster1
-    namespace: default
+    namespace: fleet-default
     operations:
-    - {"op":"remove", "path":"/spec/failureDomains"}
+    - {"op":"remove", "path":"/spec/loadBalancer"}
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: cluster1-control-plane
+    namespace: fleet-default
+    operations:
+    - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}
+  - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DockerMachineTemplate
+    name: cluster1-md-0
+    namespace: fleet-default
+    operations:
+    - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}

--- a/clusters/fleet.yaml
+++ b/clusters/fleet.yaml
@@ -1,22 +1,22 @@
-namespace: fleet-default
+namespace: default
 
 diff:
   comparePatches:
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
     name: cluster1
-    namespace: fleet-default
+    namespace: default
     operations:
     - {"op":"remove", "path":"/spec/loadBalancer"}
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerMachineTemplate
     name: cluster1-control-plane
-    namespace: fleet-default
+    namespace: default
     operations:
     - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerMachineTemplate
     name: cluster1-md-0
-    namespace: fleet-default
+    namespace: default
     operations:
     - {"op":"remove", "path":"/spec/template/spec/bootstrapTimeout"}


### PR DESCRIPTION
This PR makes following changes in `docker-rke2` branch:
* the gitrepo is `Active` instead of `Modified`
* updated README.md
* bumped RKE2 to `v1.28.9+rke2r1`

**WARNING: proposed changes with newer RKE2 in combination with used `kindest/node` requires kernel with enabled cgroup2fs**
 
Tested on `rancher:v2.8-head` with `rancher-turtles:0.8.0` operator and `capi:0.5.0` UI extension.

The cluster is provisioned and gitrepo is `Active`:
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/710251df-d3e3-497e-b281-fa324ab87b41)

And all reasources are `Ready`:
![image](https://github.com/rancher-sandbox/rancher-turtles-fleet-example/assets/12828077/f66d3a22-143a-4cdc-a850-2288ffcd2ac4)

