### PR TITLE
Add kindnet data

### DIFF
--- a/classes/quickstart.yaml
+++ b/classes/quickstart.yaml
@@ -277,3 +277,141 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration: {}
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: quick-start-crs-0
+  namespace: default
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: quick-start-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-quick-start-crs-0
+  strategy: ApplyOnce
+---
+apiVersion: v1
+data:
+  kindnet.yaml: |
+    # kindnetd networking manifest
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: kindnet
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - list
+          - watch
+          - patch
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - get
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: kindnet
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: kindnet
+    subjects:
+      - kind: ServiceAccount
+        name: kindnet
+        namespace: kube-system
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: kindnet
+      namespace: kube-system
+    ---
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: kindnet
+      namespace: kube-system
+      labels:
+        tier: node
+        app: kindnet
+        k8s-app: kindnet
+    spec:
+      selector:
+        matchLabels:
+          app: kindnet
+      template:
+        metadata:
+          labels:
+            tier: node
+            app: kindnet
+            k8s-app: kindnet
+        spec:
+          hostNetwork: true
+          tolerations:
+            - operator: Exists
+              effect: NoSchedule
+          serviceAccountName: kindnet
+          containers:
+            - name: kindnet-cni
+              image: kindest/kindnetd:v20230330-48f316cd
+              env:
+                - name: HOST_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: POD_SUBNET
+                  value: '192.168.0.0/16'
+              volumeMounts:
+                - name: cni-cfg
+                  mountPath: /etc/cni/net.d
+                - name: xtables-lock
+                  mountPath: /run/xtables.lock
+                  readOnly: false
+                - name: lib-modules
+                  mountPath: /lib/modules
+                  readOnly: true
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "50Mi"
+                limits:
+                  cpu: "100m"
+                  memory: "50Mi"
+              securityContext:
+                privileged: false
+                capabilities:
+                  add: ["NET_RAW", "NET_ADMIN"]
+          volumes:
+            - name: cni-bin
+              hostPath:
+                path: /opt/cni/bin
+                type: DirectoryOrCreate
+            - name: cni-cfg
+              hostPath:
+                path: /etc/cni/net.d
+                type: DirectoryOrCreate
+            - name: xtables-lock
+              hostPath:
+                path: /run/xtables.lock
+                type: FileOrCreate
+            - name: lib-modules
+              hostPath:
+                path: /lib/modules
+kind: ConfigMap
+metadata:
+  name: cni-quick-start-crs-0
+  namespace: default

--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster1
   namespace: default
   labels:
+    cni: quick-start-crs-0
     cluster-api.cattle.io/rancher-auto-import: "true"
 spec:
   clusterNetwork:


### PR DESCRIPTION
This PR adds kindnet cni data to clusterclass for cluster nodes.

![image](https://github.com/user-attachments/assets/601265bb-63cf-4350-9e97-66578aa242e8)
