### PR TITLE
Keep LB config map on deletion

### DIFF
--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -176,3 +176,5 @@ kind: ConfigMap
 metadata:
   name: cluster1-lb-config
   namespace: default
+  annotations:
+    "helm.sh/resource-policy": keep


### PR DESCRIPTION
This should prevent removal of LB configmap, referenced from the cluster spec, which causes in some cases inability to remove cluster entirely

Fixes: https://github.com/rancher/turtles/issues/685