### PR TITLE
split class and cluster definition in two files

### DIFF
--- a/capz/cluster-template-aks-clusterclass.yaml
+++ b/capz/cluster-template-aks-clusterclass.yaml
@@ -134,25 +134,3 @@ metadata:
   name: cluster-identity-secret
   namespace: default
 type: Opaque
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: ${CLUSTER_NAME}
-  namespace: default
-spec:
-  clusterNetwork:
-    pods:
-      cidrBlocks:
-      - 192.168.0.0/16
-  topology:
-    class: ${CLUSTER_CLASS_NAME}
-    version: ${KUBERNETES_VERSION}
-    workers:
-      machinePools:
-      - class: default-system
-        name: mp-0
-        replicas: 1
-      - class: default-worker
-        name: mp-1
-        replicas: 1

--- a/capz/cluster-template-aks-topology.yaml
+++ b/capz/cluster-template-aks-topology.yaml
@@ -1,0 +1,21 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  namespace: default
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+  topology:
+    class: ${CLUSTER_CLASS_NAME}
+    version: ${KUBERNETES_VERSION}
+    workers:
+      machinePools:
+      - class: default-system
+        name: mp-0
+        replicas: 1
+      - class: default-worker
+        name: mp-1
+        replicas: 1


### PR DESCRIPTION
# Description

Split content of CAPZ sample template into two files: one for ClusterClass and one for Cluster definition.