### PR TITLE
Use machineTemplate

### DIFF
--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -62,6 +62,12 @@ spec:
     disableComponents:
       kubernetesComponents:
       - cloudController
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DockerMachineTemplate
+      name:  cluster1-control-plane
+    nodeDrainTimeout: 30s
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerMachineTemplate


### PR DESCRIPTION
Related to https://github.com/rancher/cluster-api-provider-rke2/pull/542

This adds the `machineTemplate.infrastructureRef`.

The existing `.infrastructureRef` was not removed to guarantee compatibility with current versions of RKE2 provider (<= 0.10.0)
