### PR TITLE
Fix rke2configtemplate.spec error

### DIFF
--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -91,6 +91,9 @@ kind: RKE2ConfigTemplate
 metadata:
   name: cluster1-md-0
   namespace: default
+spec:
+  template:
+    spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment


### PR DESCRIPTION
Rancher manager failed with:

```
ErrApplied(1) [Cluster fleet-local/local: failed to create resource: RKE2ConfigTemplate.bootstrap.cluster.x-k8s.io "cluster1-md-0" is invalid: [spec: Required value, <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation]]
```

ping @anmazzotti 