### PR TITLE
🐛 Template changes/fixes

### DIFF
--- a/docker-rke2.yaml
+++ b/docker-rke2.yaml
@@ -90,6 +90,7 @@ kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
   namespace: ${NAMESPACE}
+spec: {}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment

--- a/docker-rke2.yaml
+++ b/docker-rke2.yaml
@@ -4,6 +4,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerCluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -15,6 +16,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: ${CLUSTER_NAME}
+  namespace: ${NAMESPACE}
 spec:
   clusterNetwork:
     pods:
@@ -37,7 +39,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -48,7 +50,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
   name: ${CLUSTER_NAME}-control-plane
-  namespace: default
+  namespace: ${NAMESPACE}
   annotations:
     "helm.sh/resource-policy": keep
 spec: 
@@ -73,7 +75,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  namespace: ${NAMESPACE}
 spec:
   template:
     spec:
@@ -84,13 +86,13 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  namespace: ${NAMESPACE}
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: ${CLUSTER_NAME}-md-0
-  namespace: default
+  namespace: ${NAMESPACE}
   annotations:
     "helm.sh/resource-policy": keep
 spec:
@@ -175,4 +177,4 @@ data:
 kind: ConfigMap
 metadata:
   name: ${CLUSTER_NAME}-lb-config
-  namespace: default
+  namespace: ${NAMESPACE}

--- a/docker-rke2.yaml
+++ b/docker-rke2.yaml
@@ -155,8 +155,8 @@ data:
       option httpchk GET /healthz
       http-check expect status 401
       # TODO: we should be verifying (!)
-      {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ JoinHostPort $address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
+      {{range $server, $backend := .BackendServers}}
+      server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
       {{- end}}
 
     frontend rke2-join
@@ -170,7 +170,7 @@ data:
       option httpchk GET /v1-rke2/readyz
       http-check expect status 403
       {{range $server, $address := .BackendServers}}
-      server {{ $server }} {{ $address }}:9345 check check-ssl verify none
+      server {{ $server }} {{ $address.Address }}:9345 check check-ssl verify none
       {{- end}}
 kind: ConfigMap
 metadata:

--- a/docker-rke2.yaml
+++ b/docker-rke2.yaml
@@ -61,6 +61,9 @@ spec:
       maxSurge: 1
     type: RollingUpdate
   serverConfig:
+    kubeAPIServer:
+      extraArgs:
+      - --anonymous-auth=true
     disableComponents:
       kubernetesComponents:
       - cloudController

--- a/docker-rke2.yaml
+++ b/docker-rke2.yaml
@@ -155,8 +155,6 @@ data:
 
     backend kube-apiservers
       option httpchk GET /healthz
-      http-check expect status 401
-      # TODO: we should be verifying (!)
       {{range $server, $backend := .BackendServers}}
       server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} check check-ssl verify none resolvers docker resolve-prefer {{ if $.IPv6 -}} ipv6 {{- else -}} ipv4 {{- end }}
       {{- end}}


### PR DESCRIPTION
This PR does two things:
* Allow user to choose namespace instead of deploying everything into `default` ns
* Use `address.Address` instead of `address` in the Go template 