### PR TITLE
Do not use default namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ Switch to the branch to read further information.
 
 The [clusters](./clusters/) folder contains the definition for the clusters that you want to create and have imported into Rancher Manager. These definitions can be created using **clusterctl** or hand crafted. See the [Rancher Turtles documentation](https://rancher.github.io/turtles-docs/) for further details.
 
-The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **default**.
+The [fleet.yaml](./clusters/fleet.yaml) file contains configuration used by Fleet when creating bundles. Specifically in this file we are declaring that the cluster definitions should be placed in a namespace called **capi-clusters**.
 
-You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **default** namespace to have the cluster auto-imported.
+You will need to add the **cluster-api.cattle.io/rancher-auto-import** label with a value of **true** to the **capi-clusters** namespace to have the cluster auto-imported.

--- a/clusters/cluster1.yaml
+++ b/clusters/cluster1.yaml
@@ -1,20 +1,20 @@
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerCluster
 metadata:
-  name: cluster1
-  namespace: default
+  name: capi-cl1
+  namespace: capi-clusters
   annotations:
     "helm.sh/resource-policy": keep
 spec:
   loadBalancer:
     customHAProxyConfigTemplateRef:
-      name: cluster1-lb-config
+      name: capi-cl1-lb-config
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: cluster1
-  namespace: default
+  name: capi-cl1
+  namespace: capi-clusters
 spec:
   clusterNetwork:
     pods:
@@ -27,17 +27,17 @@ spec:
   controlPlaneRef:
     apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: RKE2ControlPlane
-    name: cluster1-control-plane
+    name: capi-cl1-cp
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
-    name: cluster1
+    name: capi-cl1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: cluster1-control-plane
-  namespace: default
+  name: capi-cl1-cp
+  namespace: capi-clusters
 spec:
   template:
     spec:
@@ -47,8 +47,8 @@ spec:
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: RKE2ControlPlane
 metadata:
-  name: cluster1-control-plane
-  namespace: default
+  name: capi-cl1-cp
+  namespace: capi-clusters
   annotations:
     "helm.sh/resource-policy": keep
 spec: 
@@ -66,20 +66,20 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DockerMachineTemplate
-      name:  cluster1-control-plane
+      name:  capi-cl1-cp
     nodeDrainTimeout: 30s
   infrastructureRef:
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerMachineTemplate
-    name:  cluster1-control-plane
+    name:  capi-cl1-cp
   nodeDrainTimeout: 30s
   version: v1.26.4+rke2r1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerMachineTemplate
 metadata:
-  name: cluster1-md-0
-  namespace: default
+  name: capi-cl1-md0
+  namespace: capi-clusters
 spec:
   template:
     spec:
@@ -89,8 +89,8 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: RKE2ConfigTemplate
 metadata:
-  name: cluster1-md-0
-  namespace: default
+  name: capi-cl1-md0
+  namespace: capi-clusters
 spec:
   template:
     spec: {}
@@ -98,12 +98,12 @@ spec:
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
-  name: cluster1-md-0
-  namespace: default
+  name: capi-cl1-md0
+  namespace: capi-clusters
   annotations:
     "helm.sh/resource-policy": keep
 spec:
-  clusterName: cluster1
+  clusterName: capi-cl1
   replicas: 1
   selector:
     matchLabels: null
@@ -113,12 +113,12 @@ spec:
         configRef:
           apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: RKE2ConfigTemplate
-          name: cluster1-md-0
-      clusterName: cluster1
+          name: capi-cl1-md0
+      clusterName: capi-cl1
       infrastructureRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: DockerMachineTemplate
-        name: cluster1-md-0
+        name: capi-cl1-md0
       version: v1.26.4+rke2r1
 ---
 apiVersion: v1
@@ -183,7 +183,7 @@ data:
       {{- end}}
 kind: ConfigMap
 metadata:
-  name: cluster1-lb-config
-  namespace: default
+  name: capi-cl1-lb-config
+  namespace: capi-clusters
   annotations:
     "helm.sh/resource-policy": keep

--- a/clusters/fleet.yaml
+++ b/clusters/fleet.yaml
@@ -1,10 +1,10 @@
-namespace: default
+namespace: capi-clusters
 
 diff:
   comparePatches:
   - apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
     kind: DockerCluster
-    name: cluster1
-    namespace: default
+    name: capi-cl1
+    namespace: capi-clusters
     operations:
     - {"op":"remove", "path":"/spec/failureDomains"}


### PR DESCRIPTION
It is bad practice to use default namespace, due to:
- lack of isolation
- security risks
- resources management
- scalability issues